### PR TITLE
Support localize redirect of a localize-skipped route and skip localization of a route segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,16 @@ Make sure you therefore place most common language (e.g. 'en') as a first string
 
 Sometimes you might have a need to have certain routes excluded from the localization process e.g. login page, registration page etc. This is possible by setting flag `skipRouteLocalization` on route's data object.
 
+In case you want to redirect to an url when skipRouteLocalization is activated, you can also provide config option `localizeRedirectTo` to skip route localization but localize redirect to. Otherwise, route and redirectTo will not be translated.
+
 ```ts
 let routes = [
   // this route gets localized
   { path: 'home', component: HomeComponent },
   // this route will not be localized
   { path: 'login', component: LoginComponent, data: { skipRouteLocalization: true } }
+    // this route will not be localized, but redirect to will do
+  { path: 'logout', redirectTo: 'login', data: { skipRouteLocalization: { localizeRedirectTo: true } } }
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,15 @@ Working example can be found [here](https://github.com/meeroslav/universal-local
 
 `Localize router` intercepts Router initialization and translates each `path` and `redirectTo` path of Routes.
 The translation process is done with [ngx-translate](https://github.com/ngx-translate/core). In order to separate 
-router translations from normal application translations we use `prefix`. Default value for prefix is `ROUTES.`.
+router translations from normal application translations we use `prefix`. Default value for prefix is `ROUTES.`. Finally, in order to avoid accidentally translating a URL segment that should not be translated, you can optionally use `escapePrefix` so the prefix gets stripped and the segment doesn't get translated. Default `escapePrefix`is unset. 
+
 ```
 'home' -> 'ROUTES.home'
+```
+
+Example to escape the translation of the param with `escapePrefix: 'ESCAPE.'`
+```
+'ESCAPE.param' -> 'param'
 ```
 
 Upon every route change `Localize router` kicks in to check if there was a change to language. Translated routes are prepended with two letter language code:

--- a/projects/ngx-translate-router-http-loader/src/lib/http-loader.ts
+++ b/projects/ngx-translate-router-http-loader/src/lib/http-loader.ts
@@ -10,6 +10,7 @@ import { Location } from '@angular/common';
 export interface ILocalizeRouterParserConfig {
   locales: Array<string>;
   prefix?: string;
+  escapePrefix?: string;
 }
 
 export class LocalizeRouterHttpLoader extends LocalizeParser {
@@ -41,6 +42,7 @@ export class LocalizeRouterHttpLoader extends LocalizeParser {
         .subscribe((data: ILocalizeRouterParserConfig) => {
           this.locales = data.locales;
           this.prefix = data.prefix || '';
+          this.escapePrefix = data.escapePrefix || '';
           this.init(routes).then(resolve);
         });
     });

--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -343,12 +343,12 @@ export abstract class LocalizeParser {
    * Get translated value
    */
   private translateText(key: string): string {
-    if (!this._translationObject) {
-      return key;
-    }
     if (this.escapePrefix && key.startsWith(this.escapePrefix)) {
       return key.replace(this.escapePrefix, '');
     } else {
+      if (!this._translationObject) {
+        return key;
+      }
       const fullKey = this.prefix + key;
       const res = this.translate.getParsedResult(this._translationObject, fullKey);
       return res !== fullKey ? res : key;

--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -107,6 +107,9 @@ export abstract class LocalizeParser {
     /** exclude certain routes */
     for (let i = children.length - 1; i >= 0; i--) {
       if (children[i].data && children[i].data['skipRouteLocalization']) {
+        if (children[i].data['skipRouteLocalization']['localizeRedirectTo'] && children[i].redirectTo !== undefined) {
+          this._translateProperty(children[i], 'redirectTo', true);
+        }
         if (this.settings.alwaysSetPrefix) {
           // add directly to routes
           this.routes.push(children[i]);

--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -108,7 +108,7 @@ export abstract class LocalizeParser {
     for (let i = children.length - 1; i >= 0; i--) {
       if (children[i].data && children[i].data['skipRouteLocalization']) {
         if (children[i].data['skipRouteLocalization']['localizeRedirectTo'] && children[i].redirectTo !== undefined) {
-          this._translateProperty(children[i], 'redirectTo', true);
+          this._translateProperty(children[i], 'redirectTo', !children[i].redirectTo.indexOf('/'));
         }
         if (this.settings.alwaysSetPrefix) {
           // add directly to routes

--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -17,6 +17,7 @@ export abstract class LocalizeParser {
   defaultLang: string;
 
   protected prefix: string;
+  protected escapePrefix: string;
 
   private _translationObject: any;
   private _wildcardRoute: Route;
@@ -342,9 +343,13 @@ export abstract class LocalizeParser {
     if (!this._translationObject) {
       return key;
     }
-    const fullKey = this.prefix + key;
-    const res = this.translate.getParsedResult(this._translationObject, fullKey);
-    return res !== fullKey ? res : key;
+    if (this.escapePrefix && key.startsWith(this.escapePrefix)) {
+      return key.replace(this.escapePrefix, '');
+    } else {
+      const fullKey = this.prefix + key;
+      const res = this.translate.getParsedResult(this._translationObject, fullKey);
+      return res !== fullKey ? res : key;
+    }
   }
 }
 
@@ -357,10 +362,11 @@ export class ManualParserLoader extends LocalizeParser {
    * CTOR
    */
   constructor(translate: TranslateService, location: Location, settings: LocalizeRouterSettings,
-    locales: string[] = ['en'], prefix: string = 'ROUTES.') {
+    locales: string[] = ['en'], prefix: string = 'ROUTES.', escapePrefix: string = '') {
     super(translate, location, settings);
     this.locales = locales;
     this.prefix = prefix || '';
+    this.escapePrefix = escapePrefix || '';
   }
 
   /**

--- a/src/assets/locales.json
+++ b/src/assets/locales.json
@@ -1,5 +1,5 @@
 {
   "locales": ["en", "fr"],
   "prefix": "ROUTES.",
-  "exclusionPrefix": "IGNORE."
+  "escapePrefix": "IGNORE."
 }

--- a/src/assets/locales.json
+++ b/src/assets/locales.json
@@ -1,4 +1,5 @@
 {
   "locales": ["en", "fr"],
-  "prefix": "ROUTES."
+  "prefix": "ROUTES.",
+  "exclusionPrefix": "IGNORE."
 }


### PR DESCRIPTION
Hi!

Following the open discussion https://github.com/gilsdav/ngx-translate-router/issues/16 between you and @Nekronik (we have been working together), we are proposing this pull request to support:

### Allow localize redirect of a localize-skipped route

Solution: In case you want to redirect to an url when skipRouteLocalization is activated, you can also provide config option `localizeRedirectTo` to skip route localization but localize redirect to. Otherwise, route and redirectTo will not be translated.

### Skip the localization of a segment of the route

Solution: In order to avoid accidentally translating a URL segment that should not be translated, you can optionally use `escapePrefix` so the prefix gets stripped and the segment doesn't get translated. Default `escapePrefix`is unset. 

Example to escape the translation of the param with `escapePrefix: 'ESCAPE.'`
```
'ESCAPE.param' -> 'param'
```

We have updated @Nekronik example repo, with the usage of this two new features: Nekronik/angular-vrwvgb#1 Notice that you should link this pull request on the package.json for it to work :) 

We hope it helps!
