### PR TITLE
feat: localize matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,49 @@ Do you use same path to load multiple lazy-loaded modules and you have wrong com
   }
 ```
 
+#### Matcher params translation
+
+In case you want to translate some params of matcher, `localizeMatcher` provides you the way to do it through a function per each param.
+
+Example: 
+
+```
+  {
+    path: 'matcher',
+    children: [
+      {
+        matcher: detailMatcher,
+        loadChildren: () => import('./matcher/matcher-detail/matcher-detail.module').then(mod => mod.MatcherDetailModule)
+      },
+      {
+        matcher: baseMatcher,
+        loadChildren: () => import('./matcher/matcher.module').then(mod => mod.MatcherModule),
+        data: {
+          localizeMatcher: {
+            params: {
+              mapPage: shouldTranslateMap
+            }
+          }
+        }
+      }
+    ]
+  }
+
+...
+
+export function shouldTranslateMap(param: string): string {
+  if (isNaN(+param)) {
+    return 'map';
+  }
+  return null;
+}
+
+```
+
+The output of the function should be `falsy` if the param must not be translated or should return the `key` (without prefix) you want to use when translating if you want to translate the param. 
+
+Notice that any function that you use in `localizeMatcher` must be exported so it is later available. 
+
 ### Pipe
 
 `LocalizeRouterPipe` is used to translate `routerLink` directive's content. Pipe can be appended to partial strings in the routerLink's definition or to entire array element:

--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -381,6 +381,14 @@ export abstract class LocalizeParser {
   public formatQueryParams(params: Params): string {
     return Object.keys(params).map(key => key + '=' + params[key]).join('&');
   }
+
+  public getPrefix(): string {
+    return this.prefix;
+  }
+
+  public getEscapePrefix(): string {
+    return this.escapePrefix;
+  }
 }
 
 /**

--- a/projects/ngx-translate-router/src/lib/localize-router.service.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.service.ts
@@ -157,9 +157,9 @@ export class LocalizeRouterService {
   }
 
   private parseSegmentValueMatcher(snapshot: ActivatedRouteSnapshot): string[] {
+    const localizeMatcherParams = snapshot.data && snapshot.data.localizeMatcher && snapshot.data.localizeMatcher.params || { };
     const subPathSegments: string[] = snapshot.url.map(segment => segment.path)
       .map((s: string, i: number) => {
-        const localizeMatcherParams = snapshot.data && snapshot.data.localizeMatcher && snapshot.data.localizeMatcher.params || { };
         const matchedParam = Object.entries(snapshot.params).find((pair) => pair[1] === s);
         const val = matchedParam && localizeMatcherParams[matchedParam[0]] ? localizeMatcherParams[matchedParam[0]](s) : null;
         return val || `${this.parser.getEscapePrefix()}${s}`;

--- a/projects/ngx-translate-router/src/lib/localize-router.service.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.service.ts
@@ -159,9 +159,9 @@ export class LocalizeRouterService {
   private parseSegmentValueMatcher(snapshot: ActivatedRouteSnapshot): string[] {
     const subPathSegments: string[] = snapshot.url.map(segment => segment.path)
       .map((s: string, i: number) => {
-        const localizeMatcherParams = snapshot.data && snapshot.data.localizeMatcher && snapshot.data.localizeMatcher.params || {};
-        const [paramName] = Object.entries(snapshot.params).find(pair => pair[1] === s);
-        const val = localizeMatcherParams[paramName] ? localizeMatcherParams[paramName](s) : null;
+        const localizeMatcherParams = snapshot.data && snapshot.data.localizeMatcher && snapshot.data.localizeMatcher.params || { };
+        const matchedParam = Object.entries(snapshot.params).find((pair) => pair[1] === s);
+        const val = matchedParam && localizeMatcherParams[matchedParam[0]] ? localizeMatcherParams[matchedParam[0]](s) : null;
         return val || `${this.parser.getEscapePrefix()}${s}`;
       });
     return subPathSegments;

--- a/projects/ngx-translate-router/src/lib/localize-router.service.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.service.ts
@@ -160,7 +160,7 @@ export class LocalizeRouterService {
     const subPathSegments: string[] = snapshot.url.map(segment => segment.path)
       .map((s: string, i: number) => {
         const localizeMatcherParams = snapshot.data && snapshot.data.localizeMatcher && snapshot.data.localizeMatcher.params || {};
-        const [paramName] = Object.entries(snapshot.params).find(([_, value]) => value === s);
+        const [paramName] = Object.entries(snapshot.params).find(pair => pair[1] === s);
         const val = localizeMatcherParams[paramName] ? localizeMatcherParams[paramName](s) : null;
         return val || `${this.parser.getEscapePrefix()}${s}`;
       });

--- a/projects/ngx-translate-router/src/lib/localize-router.service.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.service.ts
@@ -135,7 +135,7 @@ export class LocalizeRouterService {
    * Extracts new segment value based on routeConfig and url
    */
   private parseSegmentValue(snapshot: ActivatedRouteSnapshot): string {
-    if (snapshot.routeConfig.matcher) {
+    if (snapshot.routeConfig && snapshot.routeConfig.matcher) {
       const subPathSegments = this.parseSegmentValueMatcher(snapshot);
       return subPathSegments.map((s: string, i: number) => s.indexOf(':') === 0 ? snapshot.url[i].path : s).join('/');
     } else if (snapshot.data.localizeRouter) {

--- a/projects/ngx-translate-router/tsconfig.lib.json
+++ b/projects/ngx-translate-router/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "types": [],
     "lib": [
       "dom",
-      "es2015"
+      "es2018"
     ]
   },
   "angularCompilerOptions": {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,65 +12,95 @@ import {
 import { LocalizeRouterHttpLoader } from '@gilsdav/ngx-translate-router-http-loader';
 
 import { HomeComponent } from './home/home.component';
-
+import { baseMatcher } from './matcher/matcher.module';
+import { detailMatcher } from './matcher/matcher-detail/matcher-detail.module';
 
 // export function ManualLoaderFactory(translate: TranslateService, location: Location, settings: LocalizeRouterSettings) {
 //     return new ManualParserLoader(translate, location, settings, ['en', 'fr'], 'ROUTES.', '!');
 // }
 
 export function HttpLoaderFactory(translate: TranslateService, location: Location, settings: LocalizeRouterSettings, http: HttpClient) {
-  return new LocalizeRouterHttpLoader(translate, location, {...settings, alwaysSetPrefix: true}, http);
+  return new LocalizeRouterHttpLoader(translate, location, { ...settings, alwaysSetPrefix: true }, http);
 }
 
 export const routes: Routes = [
-    // { path: '', redirectTo: '/home', pathMatch: 'full' },
-    {
-      path: '',
-      component: HomeComponent, loadChildren: () => import('./test/test.module').then(mod => mod.TestModule),
-      data: { discriminantPathKey: 'TESTPATH' }
-    },
-    {
-      path: '',
-      loadChildren: () => import('./test2/test.module').then(mod => mod.TestModule),
-      data: { discriminantPathKey: 'TEST2PATH' }
-    },
-    {
-      path: '',
-      loadChildren: () => import('./test3/test.module').then(mod => mod.TestModule),
-      data: { discriminantPathKey: 'TEST3PATH' }
-    },
-    { path: 'home', component: HomeComponent },
-    // { path: 'test', component: HomeComponent, loadChildren: './test/test.module#TestModule' },
-    { path: 'test', component: HomeComponent, loadChildren: () => import('./test/test.module').then(mod => mod.TestModule) },
-    { path: '!test', component: HomeComponent, loadChildren: () => import('./test/test.module').then(mod => mod.TestModule) },
+  // { path: '', redirectTo: '/home', pathMatch: 'full' },
+  {
+    path: '',
+    component: HomeComponent, loadChildren: () => import('./test/test.module').then(mod => mod.TestModule),
+    data: { discriminantPathKey: 'TESTPATH' }
+  },
+  {
+    path: '',
+    loadChildren: () => import('./test2/test.module').then(mod => mod.TestModule),
+    data: { discriminantPathKey: 'TEST2PATH' }
+  },
+  {
+    path: '',
+    loadChildren: () => import('./test3/test.module').then(mod => mod.TestModule),
+    data: { discriminantPathKey: 'TEST3PATH' }
+  },
+  {
+    path: 'matcher',
+    children: [
+      {
+        matcher: detailMatcher,
+        loadChildren: () => import('./matcher/matcher-detail/matcher-detail.module').then(mod => mod.MatcherDetailModule)
+      },
+      {
+        matcher: baseMatcher,
+        loadChildren: () => import('./matcher/matcher.module').then(mod => mod.MatcherModule),
+        data: {
+          localizeMatcher: {
+            params: {
+              mapPage: shouldTranslateMap
+            }
+          }
+        }
+      }
+    ]
+  },
+  { path: 'home', component: HomeComponent },
+  // { path: 'test', component: HomeComponent, loadChildren: './test/test.module#TestModule' },
+  { path: 'test', component: HomeComponent, loadChildren: () => import('./test/test.module').then(mod => mod.TestModule) },
+  { path: '!test', component: HomeComponent, loadChildren: () => import('./test/test.module').then(mod => mod.TestModule) },
 
-    { path: 'toredirect', redirectTo: '/home', data: { skipRouteLocalization: { localizeRedirectTo: true } }},
+  { path: 'toredirect', redirectTo: '/home', data: { skipRouteLocalization: { localizeRedirectTo: true } } },
 
-    { path: 'bob', children: [
-        { path: 'home/:test', component: HomeComponent }
-    ] },
-    // { path: '**', redirectTo: '/home' }
+  {
+    path: 'bob', children: [
+      { path: 'home/:test', component: HomeComponent }
+    ]
+  },
+  // { path: '**', redirectTo: '/home' }
 ];
 
+export function shouldTranslateMap(param: string): string {
+  if (isNaN(+param)) {
+    return 'map';
+  }
+  return null;
+}
+
 @NgModule({
-    imports: [
-        RouterModule.forRoot(routes),
-        LocalizeRouterModule.forRoot(routes, {
-            // parser: {
-            //     provide: LocalizeParser,
-            //     useFactory: ManualLoaderFactory,
-            //     deps: [TranslateService, Location, LocalizeRouterSettings]
-            // }
-            parser: {
-              provide: LocalizeParser,
-              useFactory: HttpLoaderFactory,
-              deps: [TranslateService, Location, LocalizeRouterSettings, HttpClient]
-            },
-            cacheMechanism: CacheMechanism.Cookie,
-            cookieFormat: '{{value}};{{expires}};path=/'
-        })
-    ],
-    exports: [RouterModule, LocalizeRouterModule]
+  imports: [
+    RouterModule.forRoot(routes),
+    LocalizeRouterModule.forRoot(routes, {
+      // parser: {
+      //     provide: LocalizeParser,
+      //     useFactory: ManualLoaderFactory,
+      //     deps: [TranslateService, Location, LocalizeRouterSettings]
+      // }
+      parser: {
+        provide: LocalizeParser,
+        useFactory: HttpLoaderFactory,
+        deps: [TranslateService, Location, LocalizeRouterSettings, HttpClient]
+      },
+      cacheMechanism: CacheMechanism.Cookie,
+      cookieFormat: '{{value}};{{expires}};path=/'
+    })
+  ],
+  exports: [RouterModule, LocalizeRouterModule]
 })
 export class AppRoutingModule { }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,4 @@
+<button (click)="switchLang()">{{ 'CHANGE_LANGUAGE' | translate }}</button>
 
 <div style="text-align:center">
   <h1>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,4 +22,9 @@ export class AppComponent implements OnInit {
       console.log('routerOutletActivation', active);
     }
 
+    public switchLang() {
+      console.log('change lang');
+      this.localize.changeLanguage(this.localize.parser.currentLang === 'fr' ? 'en' : 'fr');
+    }
+
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -2,9 +2,8 @@
   {{'TITLE' | translate}}
 </p>
 
+<p><a [routerLink]="['/matcher'] | localize">Matcher</a></p>
 <p><a [routerLink]="['/test', 'bob'] | localize">test</a></p>
 <p><a [routerLink]="['/!test', 'bob'] | localize">test2</a></p>
-
-<button (click)="switchLang()">change</button>
 
 <router-outlet (activate)="routerOutletActivation(true)" (deactivate)="routerOutletActivation(false)"></router-outlet>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { LocalizeRouterService } from '@gilsdav/ngx-translate-router';
 
 @Component({
   selector: 'app-home',
@@ -8,7 +7,7 @@ import { LocalizeRouterService } from '@gilsdav/ngx-translate-router';
 })
 export class HomeComponent implements OnInit, OnDestroy {
 
-  constructor(private localize: LocalizeRouterService) { }
+  constructor() { }
 
   ngOnInit() {
     console.log('home init');
@@ -16,11 +15,6 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     console.log('home destroy');
-  }
-
-  public switchLang() {
-    console.log('change lang');
-    this.localize.changeLanguage(this.localize.parser.currentLang === 'fr' ? 'en' : 'fr');
   }
 
   public routerOutletActivation(active: boolean) {

--- a/src/app/matcher/matcher-detail/matcher-detail.component.css
+++ b/src/app/matcher/matcher-detail/matcher-detail.component.css
@@ -1,0 +1,14 @@
+.links {
+  display: grid;
+  gap: .5rem;
+  margin: 2rem 0;
+  justify-content: start;
+}
+.links > a {
+  color: #333;
+  text-decoration: none;
+  margin-left: 2rem;
+}
+.links > a.active {
+  color: #22c;
+}

--- a/src/app/matcher/matcher-detail/matcher-detail.component.html
+++ b/src/app/matcher/matcher-detail/matcher-detail.component.html
@@ -1,0 +1,27 @@
+<div class="links">
+  <span>matcher detail</span>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc', '12345678'] | localize">['/matcher', 'aaa', 'bbb', 'ccc', '12345678']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', '12345678'] | localize">['/matcher', 'aaa', 'bbb', '12345678']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', '12345678'] | localize">['/matcher', 'aaa', '12345678']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', '12345678'] | localize">['/matcher', '12345678']</a>
+
+  <span>matcher base</span>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc', 'map'] | localize">['/matcher', 'aaa', 'bbb', 'ccc', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc', 2] | localize">['/matcher', 'aaa', 'bbb', 'ccc', 2]</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc'] | localize">['/matcher', 'aaa', 'bbb', 'ccc']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'map'] | localize">['/matcher', 'aaa', 'bbb', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 2] | localize">['/matcher', 'aaa', 'bbb', 2]</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb'] | localize">['/matcher', 'aaa', 'bbb']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'map'] | localize">['/matcher', 'aaa', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', '2'] | localize">['/matcher', 'aaa', '2']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa'] | localize">['/matcher', 'aaa']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'map'] | localize">['/matcher', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', '2'] | localize">['/matcher', '2']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher'] | localize">['/matcher']</a>
+</div>
+
+<h2>Matcher on detail</h2>
+
+<div class="list">
+  <div class="item" *ngFor="let number of [1, 2, 3, 4, 5, 6]">{{ number }}</div>
+</div>

--- a/src/app/matcher/matcher-detail/matcher-detail.component.spec.ts
+++ b/src/app/matcher/matcher-detail/matcher-detail.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MatcherDetailComponent } from './matcher-detail.component';
+
+describe('MatcherDetailComponent', () => {
+  let component: MatcherDetailComponent;
+  let fixture: ComponentFixture<MatcherDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MatcherDetailComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MatcherDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/matcher/matcher-detail/matcher-detail.component.ts
+++ b/src/app/matcher/matcher-detail/matcher-detail.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-matcher-detail',
+  templateUrl: './matcher-detail.component.html',
+  styleUrls: ['./matcher-detail.component.css']
+})
+export class MatcherDetailComponent implements OnInit {
+
+  params: string[][] = [];
+
+  constructor(
+    private route: ActivatedRoute
+  ) { }
+
+  ngOnInit() {
+    this.route.paramMap.subscribe((paramMap) => {
+      this.params = [];
+      const keys = [...paramMap.keys];
+      for (let index = keys.length - 2; index >= 0 ; index--) {
+        this.params.push(['/matcher', ...keys.slice(0, index), keys[keys.length - 1]]);
+      }
+      this.params.push(['/matcher']);
+    });
+  }
+
+}

--- a/src/app/matcher/matcher-detail/matcher-detail.module.ts
+++ b/src/app/matcher/matcher-detail/matcher-detail.module.ts
@@ -1,0 +1,61 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes, UrlSegment, UrlMatchResult } from '@angular/router';
+
+import { LocalizeRouterModule } from '@gilsdav/ngx-translate-router';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { MatcherDetailComponent } from './matcher-detail.component';
+
+export function detailMatcher(segments: UrlSegment[]): UrlMatchResult {
+  // /:id
+  // /:a/:id
+  // /:a/:b/:id
+  // /:a/:b/:c/:id
+
+  if (!segments.length || !isId(segments[segments.length - 1])) {
+    return null;
+  }
+
+  const result: UrlMatchResult = {
+    consumed: [],
+    posParams: { }
+  };
+
+  for (const segment of 'abc'.substr(0, segments.length - 1)) {
+    takeSegment(segment);
+  }
+  takeSegment('id');
+
+  return result;
+
+  function takeSegment(name: string): void {
+    const segment = segments.shift();
+    result.consumed.push(segment);
+    result.posParams[name] = segment;
+  }
+  function isId(url: UrlSegment): boolean {
+    return (url.path.startsWith('ROUTES.') ? url.path.substring(7) : url.path).match(/^[a-f\d]{8}$/i) !== null;
+  }
+}
+
+const routes: Routes = [
+  { path: '', component: MatcherDetailComponent, data: { discriminantPathKey: 'DETAIL' } }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    LocalizeRouterModule.forChild(routes),
+    TranslateModule.forChild()
+  ],
+  declarations: [
+    MatcherDetailComponent
+  ],
+  exports: [
+    RouterModule,
+    LocalizeRouterModule
+  ]
+})
+export class MatcherDetailModule { }

--- a/src/app/matcher/matcher.component.css
+++ b/src/app/matcher/matcher.component.css
@@ -1,0 +1,14 @@
+.links {
+  display: grid;
+  gap: .5rem;
+  margin: 2rem 0;
+  justify-content: start;
+}
+.links > a {
+  color: #333;
+  text-decoration: none;
+  margin-left: 2rem;
+}
+.links > a.active {
+  color: #22c;
+}

--- a/src/app/matcher/matcher.component.html
+++ b/src/app/matcher/matcher.component.html
@@ -1,0 +1,29 @@
+<div class="links">
+  <span>matcher detail</span>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc', '12345678'] | localize">['/matcher', 'aaa', 'bbb', 'ccc', '12345678']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', '12345678'] | localize">['/matcher', 'aaa', 'bbb', '12345678']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', '12345678'] | localize">['/matcher', 'aaa', '12345678']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', '12345678'] | localize">['/matcher', '12345678']</a>
+
+  <span>matcher base</span>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc', 'map'] | localize">['/matcher', 'aaa', 'bbb', 'ccc', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc', 2] | localize">['/matcher', 'aaa', 'bbb', 'ccc', 2]</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'ccc'] | localize">['/matcher', 'aaa', 'bbb', 'ccc']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 'map'] | localize">['/matcher', 'aaa', 'bbb', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb', 2] | localize">['/matcher', 'aaa', 'bbb', 2]</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'bbb'] | localize">['/matcher', 'aaa', 'bbb']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', 'map'] | localize">['/matcher', 'aaa', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa', '2'] | localize">['/matcher', 'aaa', '2']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'aaa'] | localize">['/matcher', 'aaa']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', 'map'] | localize">['/matcher', 'map']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher', '2'] | localize">['/matcher', '2']</a>
+  <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="['/matcher'] | localize">['/matcher']</a>
+</div>
+
+<h2>Matcher base</h2>
+
+<ul class="params">
+  <li *ngFor="let param of []">
+    <a routerLink="/detail/{{param.id}}">{{ param }}</a>
+  </li>
+</ul>

--- a/src/app/matcher/matcher.component.spec.ts
+++ b/src/app/matcher/matcher.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MatcherComponent } from './matcher.component';
+
+describe('MatcherComponent', () => {
+  let component: MatcherComponent;
+  let fixture: ComponentFixture<MatcherComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MatcherComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MatcherComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/matcher/matcher.component.ts
+++ b/src/app/matcher/matcher.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-matcher',
+  templateUrl: './matcher.component.html',
+  styleUrls: ['./matcher.component.css']
+})
+export class MatcherComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() { }
+
+}

--- a/src/app/matcher/matcher.module.ts
+++ b/src/app/matcher/matcher.module.ts
@@ -1,0 +1,69 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { UrlSegment, UrlMatchResult, RouterModule, Routes } from '@angular/router';
+
+import { LocalizeRouterModule } from '@gilsdav/ngx-translate-router';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { MatcherComponent } from './matcher.component';
+
+export function baseMatcher(segments: UrlSegment[]): UrlMatchResult {
+  // /
+  // /:mapPage
+  // /:a
+  // /:a/:mapPage
+  // /:a/:b
+  // /:a/:b/:mapPage
+  // /:a/:b/:c
+  // /:a/:b/:c/:mapPage
+
+  const result: UrlMatchResult = {
+    consumed: [],
+    posParams: { }
+  };
+
+  if (segments.length > 0) {
+    const last = segments.length - 1;
+    const isMap = isMapOrPage(segments[last]);
+    for (const segment of 'abc'.substr(0, isMap ? last : segments.length)) {
+      takeFirstSegment(segment);
+    }
+    if (isMap) {
+      takeFirstSegment('mapPage');
+    }
+  }
+  return result;
+
+  function takeFirstSegment(name: string): void {
+    const segment = segments.shift();
+    result.consumed.push(segment);
+    result.posParams[name] = segment;
+  }
+
+  function isMapOrPage(url: UrlSegment): boolean {
+    // This regex should include all variations for the segment
+    return url.path.match(/^(map|carte|\d+)$/i) !== null;
+  }
+}
+
+const routes: Routes = [
+  { path: '', component: MatcherComponent, data: { discriminantPathKey: 'BASE' } }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    LocalizeRouterModule.forChild(routes),
+    TranslateModule.forChild()
+  ],
+  declarations: [
+    MatcherComponent
+  ],
+  providers: [],
+  exports: [
+    RouterModule,
+    LocalizeRouterModule
+  ]
+})
+export class MatcherModule { }

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -2,5 +2,8 @@
     "TITLE": "hello",
     "ROUTES.home": "home",
     "ROUTES.test": "mytest",
-    "ROUTES.bob": "george"
+    "ROUTES.bob": "george",
+    "ROUTES.map": "map",
+    "ROUTES.matcher": "mymatcher",
+    "CHANGE_LANGUAGE": "Change language"
 }

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -2,5 +2,8 @@
     "TITLE": "coucou",
     "ROUTES.home": "acceuil",
     "ROUTES.test": "testounet",
-    "ROUTES.bob": "bobie"
+    "ROUTES.bob": "bobie",
+    "ROUTES.map": "carte",
+    "ROUTES.matcher": "monmatcher",
+    "CHANGE_LANGUAGE": "Changer de langue"
 }


### PR DESCRIPTION
In case you want to translate some params of matcher, `localizeMatcher` provides you the way to do it through a function per each param.

Notice that I have worked on discriminant path key branch, as I was requiring discriminantPathKey in a few examples to make sure it was working properly. 

Example: 

```
  {
    path: 'matcher',
    children: [
      {
        matcher: detailMatcher,
        loadChildren: () => import('./matcher/matcher-detail/matcher-detail.module').then(mod => mod.MatcherDetailModule)
      },
      {
        matcher: baseMatcher,
        loadChildren: () => import('./matcher/matcher.module').then(mod => mod.MatcherModule),
        data: {
          localizeMatcher: {
            params: {
              mapPage: shouldTranslateMap
            }
          }
        }
      }
    ]
  }

...

export function shouldTranslateMap(param: string): string {
  if (isNaN(+param)) {
    return 'map';
  }
  return null;
}

```

The output of the function should be `falsy` if the param must not be translated or should return the `key` (without prefix) you want to use when translating if you want to translate the param. 

Notice that any function that you use in `localizeMatcher` must be exported so it is later available. 

Should close https://github.com/gilsdav/ngx-translate-router/issues/16