### PR TITLE
wrap `detectChanges` in a setTimeout call

### DIFF
--- a/projects/ngx-translate-router/src/lib/localize-router.pipe.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.pipe.ts
@@ -51,7 +51,10 @@ export class LocalizeRouterPipe implements PipeTransform, OnDestroy {
     if (view && (view.state & VIEW_DESTROYED_STATE)) {
       return this.value;
     }
-    this._ref.detectChanges();
+    setTimeout(() => {
+      this._ref.detectChanges();
+    }, 0)
+
     return this.value;
   }
 }


### PR DESCRIPTION
There is a [bug](https://github.com/angular/angular/issues/38611) in the Angular framework that impact some applications that use your library with Ivy.

Due to that [bug](https://github.com/angular/angular/issues/38611#issuecomment-683277944), a runtime error is thrown when calling `detectChanges` inside the `transform` method of the `LocalizeRouterPipe` :

```jsx
core.js:4200 ERROR TypeError: Cannot read property 'call' of undefined
    at callHook (core.js:3045)
    at callHooks (core.js:3008)
    at executeCheckHooks (core.js:2941)
    at selectIndexInternal (core.js:6177)
    at Module.ɵɵadvance (core.js:6156)
    at AppComponent_Template (app.component.html:1)
    at executeTemplate (core.js:7306)
    at refreshView (core.js:7175)
    at refreshComponent (core.js:8329)
    at refreshChildComponents (core.js:6968)
```

As we don't know when the problem in the Angular framework will be resolved, I'm proposing a temporary fix by wrapping the `detectChanges` call inside a `setTimeout` function.