### PR TITLE
prevent mutations of localizeRouter.path property

### DIFF
--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -201,7 +201,7 @@ export abstract class LocalizeParser {
       routeData.localizeRouter = {};
     }
     if (!routeData.localizeRouter[property]) {
-      routeData.localizeRouter[property] = (<any>route)[property];
+      routeData.localizeRouter = {...routeData.localizeRouter, [property]: route[property] };
     }
 
     const result = this.translateRoute(routeData.localizeRouter[property]);


### PR DESCRIPTION
I looked at the problem https://github.com/gilsdav/ngx-translate-router/issues/72 again and analyzed it. 
The problem occurs because the property path is changed on the localizeRouter. If this would be implemented immutable, the error does not occur anymore.