### PR TITLE
fixing matrix params with ssr

### DIFF
--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -246,7 +246,7 @@ export abstract class LocalizeParser {
    * Get language from url
    */
   getLocationLang(url?: string): string {
-    const queryParamSplit = (url || this.location.path()).split('?');
+    const queryParamSplit = (url || this.location.path()).split(/[\?;]/);
     let pathSlices: string[] = [];
     if (queryParamSplit.length > 0) {
       pathSlices = queryParamSplit[0].split('/');


### PR DESCRIPTION
Hi there! We currently face an issue with SSR and matrix parameters. Calling the following URL:

`/en;param=value`

causes the language to not be recognized and won't match the route. This pull request adds a semicolon as a delimiter which would resolve this issue in the `getLocationLang `function.