### PR TITLE
feat: inject TitleStrategy into router factory

### DIFF
--- a/projects/ngx-translate-router/src/lib/localize-router.module.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.module.ts
@@ -4,8 +4,10 @@ import {
 } from '@angular/core';
 import { LocalizeRouterService } from './localize-router.service';
 import { DummyLocalizeParser, LocalizeParser } from './localize-router.parser';
-import { RouterModule, Routes, RouteReuseStrategy, Router, UrlSerializer, ChildrenOutletContexts,
-  ROUTES, ROUTER_CONFIGURATION, UrlHandlingStrategy } from '@angular/router';
+import {
+  RouterModule, Routes, RouteReuseStrategy, Router, UrlSerializer, ChildrenOutletContexts,
+  ROUTES, ROUTER_CONFIGURATION, UrlHandlingStrategy, DefaultTitleStrategy, TitleStrategy
+} from '@angular/router';
 import { LocalizeRouterPipe } from './localize-router.pipe';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonModule, Location } from '@angular/common';
@@ -102,6 +104,8 @@ export class LocalizeRouterModule {
             ROUTES,
             LocalizeParser,
             ROUTER_CONFIGURATION,
+            DefaultTitleStrategy,
+            [TitleStrategy, new Optional()],
             [UrlHandlingStrategy, new Optional()],
             [RouteReuseStrategy, new Optional()]
           ]

--- a/projects/ngx-translate-router/src/lib/localized-router.ts
+++ b/projects/ngx-translate-router/src/lib/localized-router.ts
@@ -1,6 +1,6 @@
 import {
-  Router, UrlSerializer, ChildrenOutletContexts, Routes,
-  Route, ExtraOptions, UrlHandlingStrategy, RouteReuseStrategy, RouterEvent, LoadChildren, ROUTES
+  Router, UrlSerializer, ChildrenOutletContexts, Routes, Route, ExtraOptions, UrlHandlingStrategy,
+  RouteReuseStrategy, RouterEvent, LoadChildren, ROUTES, DefaultTitleStrategy, TitleStrategy
 } from '@angular/router';
 import { Type, Injector, Compiler, ApplicationRef, NgModuleFactory, PLATFORM_ID } from '@angular/core';
 import { Location, isPlatformBrowser } from '@angular/common';
@@ -11,14 +11,14 @@ import { LocalizeParser } from './localize-router.parser';
 
 export class LocalizedRouter extends Router {
   constructor(
-    _rootComponentType: Type<any>|null,
+    _rootComponentType: Type<any> | null,
     _urlSerializer: UrlSerializer,
     _rootContexts: ChildrenOutletContexts,
     _location: Location, injector: Injector,
     compiler: Compiler,
     public config: Routes,
     localize: LocalizeParser
-    ) {
+  ) {
     super(_rootComponentType, _urlSerializer, _rootContexts, _location, injector, compiler, config);
     // Custom configuration
     const platformId = injector.get(PLATFORM_ID);
@@ -66,12 +66,13 @@ export class LocalizedRouter extends Router {
 
 }
 export function setupRouter(
-    ref: ApplicationRef, urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts,
-    location: Location, injector: Injector, compiler: Compiler,
-    config: Route[][], localize: LocalizeParser, opts: ExtraOptions = {}, urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy) {
+  ref: ApplicationRef, urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts,
+  location: Location, injector: Injector, compiler: Compiler,
+  config: Route[][], localize: LocalizeParser, opts: ExtraOptions = {},
+  defaultTitleStrategy: DefaultTitleStrategy, titleStrategy?: TitleStrategy,
+  urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy) {
   const router = new LocalizedRouter(
-      null, urlSerializer, contexts, location, injector, compiler, flatten(config), localize);
+    null, urlSerializer, contexts, location, injector, compiler, flatten(config), localize);
 
   if (urlHandlingStrategy) {
     router.urlHandlingStrategy = urlHandlingStrategy;
@@ -80,6 +81,8 @@ export function setupRouter(
   if (routeReuseStrategy) {
     router.routeReuseStrategy = routeReuseStrategy;
   }
+
+  router.titleStrategy = titleStrategy ?? defaultTitleStrategy;
 
   if (opts.errorHandler) {
     router.errorHandler = opts.errorHandler;
@@ -117,7 +120,7 @@ export function setupRouter(
   return router;
 }
 
-export function wrapIntoObservable<T>(value: T | NgModuleFactory<T>| Promise<T>| Observable<T>) {
+export function wrapIntoObservable<T>(value: T | NgModuleFactory<T> | Promise<T> | Observable<T>) {
   if (isObservable(value)) {
     return value;
   }
@@ -129,5 +132,5 @@ export function wrapIntoObservable<T>(value: T | NgModuleFactory<T>| Promise<T>|
     return from(Promise.resolve(value));
   }
 
-  return of (value);
+  return of(value);
 }


### PR DESCRIPTION
Fixes #129

---

The implementation is inspired by the way [setupRouter()](https://github.com/angular/angular/blob/14.2.0/packages/router/src/router.ts#L326) injects the `TitleStrategy` in the `angular/router` library, but it is modified to make sure it fits the architecture of this library.

I noticed that unit tests don't seem to work, but I tested this build of the library in an app where we currently use the modified library mentioned in #129 and everything is working as intended, including the case where the default TitleStrategy is used.