### PR TITLE
Update to Angular 15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ Based on and extension of [ngx-translate](https://github.com/ngx-translate/core)
 
 **Version to choose :**
 
-| angular version | translate-router | http-loader | type | remarks |
-| --------------- | ---------------- | ----------- | ---- | ------- |
+| angular version | translate-router | http-loader | type   | remarks                |
+|-----------------|------------------|-------------|--------|------------------------|
 | 6 - 7           | 1.0.2            | 1.0.1       | legacy |
 | 7               | 1.7.3            | 1.1.0       | legacy |
 | 8               | 2.2.3            | 1.1.0       | legacy |
 | 8 - 12          | 3.1.9            | 1.1.2       | active |
 | 13              | 4.0.1            | 2.0.0       | active |
-| 14              | 5.1.1            | 2.0.0       | active | need rxjs 7 or higher |
-| 15              | 6.0.0            | 2.0.0       | active | minimum angular 15.0.3
+| 14              | 5.1.1            | 2.0.0       | active | need rxjs 7 or higher  |
+| 15              | 6.0.0            | 2.0.0       | active | minimum angular 15.0.3 |
+| 15.1            | 6.1.0            | 2.0.0       | active | minimum angular 15.1.0 |
 
 Demo project can be found under sub folder `src`.
 

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^15.0.3",
-    "@angular/common": "^15.0.3",
-    "@angular/compiler": "^15.0.3",
-    "@angular/core": "^15.0.3",
-    "@angular/platform-browser": "^15.0.3",
-    "@angular/platform-browser-dynamic": "^15.0.3",
-    "@angular/router": "^15.0.3",
+    "@angular/animations": "^15.1.0",
+    "@angular/common": "^15.1.0",
+    "@angular/compiler": "^15.1.0",
+    "@angular/core": "^15.1.0",
+    "@angular/platform-browser": "^15.1.0",
+    "@angular/platform-browser-dynamic": "^15.1.0",
+    "@angular/router": "^15.1.0",
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "@scullyio/scully": "0.0.102",
@@ -29,11 +29,11 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^15.0.3",
-    "@angular-devkit/build-angular": "^15.0.3",
-    "@angular/cli": "^15.0.3",
-    "@angular/language-service": "^15.0.3",
-    "ng-packagr": "^15.0.3",
+    "@angular/compiler-cli": "^15.1.0",
+    "@angular-devkit/build-angular": "^15.1.0",
+    "@angular/cli": "^15.1.0",
+    "@angular/language-service": "^15.1.0",
+    "ng-packagr": "^15.1.0",
     "@types/node": "^16.11.6",
     "@types/jasmine": "~3.10.2",
     "@types/jasminewd2": "~2.0.8",
@@ -47,6 +47,6 @@
     "karma-jasmine-html-reporter": "^1.7.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.4.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   }
 }

--- a/projects/ngx-translate-router/package.json
+++ b/projects/ngx-translate-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gilsdav/ngx-translate-router",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "homepage": "https://github.com/gilsdav/ngx-translate-router#readme",
   "license" : "MIT",
   "author": {
@@ -9,9 +9,9 @@
     "url": "https://github.com/gilsdav"
   },
   "peerDependencies": {
-    "@angular/common": ">=15.0.3",
-    "@angular/core": ">=15.0.3",
-    "@angular/router": ">=15.0.3",
+    "@angular/common": ">=15.1.0",
+    "@angular/core": ">=15.1.0",
+    "@angular/router": ">=15.1.0",
     "@ngx-translate/core": ">=11.0.1"
   }
 }

--- a/projects/ngx-translate-router/src/lib/localize-router.module.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.module.ts
@@ -46,10 +46,10 @@ export class ParserInitializer {
       if (settings.initialNavigation) {
         return new Promise<void>(resolve => {
           // @ts-ignore
-          const oldAfterPreactivation = router.afterPreactivation;
+          const oldAfterPreactivation = router.navigationTransitions.afterPreactivation;
           let firstInit = true;
           // @ts-ignore
-          router.afterPreactivation = () => {
+          router.navigationTransitions.afterPreactivation = () => {
             if (firstInit) {
               resolve();
               firstInit = false;


### PR DESCRIPTION
Due to https://github.com/angular/angular/pull/48475 `afterPreactivation` hook was moved to `navigationTransitions` field.
This change was introduced in Angular 15.1 and breaks code in ngx-transate-router library, so `initialNavigation` doesn't works.

Changes:
- Updated to Angular 15.1
- changed `router.afterPreactivation` to `router.navigationTransitions.afterPreactivation`

closes #141 