### PR TITLE
Translate routes if routes array is used in loadChildren (standalone components)

### DIFF
--- a/projects/ngx-translate-router/package.json
+++ b/projects/ngx-translate-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gilsdav/ngx-translate-router",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "homepage": "https://github.com/gilsdav/ngx-translate-router#readme",
   "license" : "MIT",
   "author": {

--- a/projects/ngx-translate-router/src/lib/localized-router.ts
+++ b/projects/ngx-translate-router/src/lib/localized-router.ts
@@ -33,7 +33,7 @@ export class LocalizedRouter extends Router {
         }
         return compiled.pipe(map(factory => {
           if (Array.isArray(factory)) {
-            return factory;
+            return this.localize.initChildRoutes([...factory]);
           }
           return {
             moduleType: factory.moduleType,


### PR DESCRIPTION
Hello, there is  a problem if we use array of routes in loadChildren (flow for standalone components).
I found part of code where routes are translated for lazy loaded modules when loadChildren is used, but translation functionality is missed for array (received if we use flow for standalone components). I just suggest to translate it as well as in case with modules.

Closes #142.