### PR TITLE
Support for ngx-translate v17

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Setting this flag on sub route has no effect as parent route would already have 
 `LocalizeRouter` depends on `ngx-translate` core service and automatically initializes it with selected locales.
 Following code is run on `LocalizeParser` init:
 ```ts
-this.translate.setDefaultLang(cachedLanguage || languageOfBrowser || firstLanguageFromConfig);
+this.translate.setFallbackLang(cachedLanguage || languageOfBrowser || firstLanguageFromConfig);
 // ...
 this.translate.use(languageFromUrl || cachedLanguage || languageOfBrowser || firstLanguageFromConfig);
 ```

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ Based on and extension of [ngx-translate](https://github.com/ngx-translate/core)
 
 **Version to choose :**
 
-| angular version | translate-router | http-loader | type   | remarks                 |
-|-----------------|------------------|-------------|--------|-------------------------|
+| angular version | translate-router | http-loader | type   | remarks                  |
+| --------------- | ---------------- | ----------- | ------ | ------------------------ |
 | 6 - 7           | 1.0.2            | 1.0.1       | legacy |
 | 7               | 1.7.3            | 1.1.0       | legacy |
 | 8               | 2.2.3            | 1.1.0       | legacy |
 | 8 - 12          | 3.1.9            | 1.1.2       | active |
 | 13              | 4.0.1            | 2.0.0       | active |
-| 14              | 5.1.1            | 2.0.0       | active | need rxjs 7 or higher   |
-| 15              | 6.0.0            | 2.0.0       | active | minimum angular 15.0.3  |
-| 15.1            | 6.1.0            | 2.0.0       | active | minimum angular 15.1.0  |
-| 16              | 7.0.0            | 2.0.0       | active | minimum angular 16      |
-| 17              | 7.1.0            | 2.0.0       | active | optional standalone API |
-| 18              | 7.2.1            | 2.0.0       | active |  |
-| 18              | 8.0.0            | 2.0.0       | active | @ngx-translate/core v17+|
+| 14              | 5.1.1            | 2.0.0       | active | need rxjs 7 or higher    |
+| 15              | 6.0.0            | 2.0.0       | active | minimum angular 15.0.3   |
+| 15.1            | 6.1.0            | 2.0.0       | active | minimum angular 15.1.0   |
+| 16              | 7.0.0            | 2.0.0       | active | minimum angular 16       |
+| 17              | 7.1.0            | 2.0.0       | active | optional standalone API  |
+| 18              | 7.2.1            | 2.0.0       | active |                          |
+| 18              | 8.0.0            | 2.0.0       | active | @ngx-translate/core v17+ |
 
 Demo project can be found under sub folder `src`.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Based on and extension of [ngx-translate](https://github.com/ngx-translate/core)
 | 16              | 7.0.0            | 2.0.0       | active | minimum angular 16      |
 | 17              | 7.1.0            | 2.0.0       | active | optional standalone API |
 | 18              | 7.2.1            | 2.0.0       | active |  |
+| 18              | 8.0.0            | 2.0.0       | active | @ngx-translate/core v17+|
 
 Demo project can be found under sub folder `src`.
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "18.0.1",
     "@angular/ssr": "^18.0.2",
     "@ngx-translate/core": "17.0.0",
-    "@ngx-translate/http-loader": "8.0.0",
+    "@ngx-translate/http-loader": "17.0.0",
     "@scullyio/scully": "0.0.102",
     "express": "^4.18.2",
     "rxjs": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-server": "18.0.1",
     "@angular/router": "18.0.1",
     "@angular/ssr": "^18.0.2",
-    "@ngx-translate/core": "15.0.0",
+    "@ngx-translate/core": "17.0.0",
     "@ngx-translate/http-loader": "8.0.0",
     "@scullyio/scully": "0.0.102",
     "express": "^4.18.2",

--- a/projects/ngx-translate-router/package.json
+++ b/projects/ngx-translate-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gilsdav/ngx-translate-router",
-  "version": "7.2.1",
+  "version": "8.0.0",
   "homepage": "https://github.com/gilsdav/ngx-translate-router#readme",
   "license" : "MIT",
   "author": {
@@ -12,6 +12,6 @@
     "@angular/common": ">=16.2.12",
     "@angular/core": ">=16.2.12",
     "@angular/router": ">=16.2.12",
-    "@ngx-translate/core": ">=15.0.0"
+    "@ngx-translate/core": ">=17.0.0"
   }
 }

--- a/projects/ngx-translate-router/src/lib/localize-router.parser.ts
+++ b/projects/ngx-translate-router/src/lib/localize-router.parser.ts
@@ -1,5 +1,5 @@
 import { Routes, Route, NavigationExtras, Params } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
+import { StrictTranslation, TranslateService } from '@ngx-translate/core';
 import { firstValueFrom, Observable, Observer } from 'rxjs';
 import { Location } from '@angular/common';
 import { CacheMechanism, LocalizeRouterSettings } from './localize-router.config';
@@ -55,7 +55,6 @@ export abstract class LocalizeParser {
     });
   } */
 
-
   /**
    * Initialize language and routes
    */
@@ -78,7 +77,7 @@ export abstract class LocalizeParser {
       this.defaultLang = this._cachedLang || browserLang || this.locales[0];
     }
     selectedLanguage = locationLang || this.defaultLang;
-    this.translate.setDefaultLang(this.defaultLang);
+    this.translate.setFallbackLang(this.defaultLang);
 
     let children: Routes = [];
     /** if set prefix is enforced */
@@ -396,7 +395,7 @@ export abstract class LocalizeParser {
   /**
    * Get translated value
    */
-  private translateText(key: string): string {
+  private translateText(key: string): StrictTranslation | Observable<StrictTranslation> {
     if (this.escapePrefix && key.startsWith(this.escapePrefix)) {
       return key.replace(this.escapePrefix, '');
     } else {
@@ -404,14 +403,14 @@ export abstract class LocalizeParser {
         return key;
       }
       const fullKey = this.prefix + key;
-      const res = this.translate.getParsedResult(this._translationObject, fullKey);
+      const res = this.translate.getParsedResult(fullKey);
       return res !== fullKey ? res : key;
     }
   }
 
   /**
    * Strategy to choose between new or old queryParams
-   * @param newExtras extras that containes new QueryParams
+   * @param newExtras extras that contains new QueryParams
    * @param currentQueryParams current query params
    */
   public chooseQueryParams(newExtras: NavigationExtras, currentQueryParams: Params) {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,33 +1,30 @@
 import { importProvidersFrom } from '@angular/core';
 
-import { createTranslateLoader } from './app.utils';
-import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { provideTranslateService } from '@ngx-translate/core';
 import { AppRoutingModule } from './app-routing.module';
 import { withInterceptorsFromDi, provideHttpClient, HttpClient } from '@angular/common/http';
 import { TranslateTitleStrategy } from './translate-title-strategy';
 import { TitleStrategy } from '@angular/router';
 import { provideClientHydration, BrowserModule } from '@angular/platform-browser';
 
-import {ApplicationConfig} from '@angular/core';
+import { ApplicationConfig } from '@angular/core';
+import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
+import { environment } from 'src/environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    importProvidersFrom(BrowserModule, AppRoutingModule, TranslateModule.forRoot({
-      loader: {
-        provide: TranslateLoader,
-        useFactory: (createTranslateLoader),
-        deps: [HttpClient]
-      }
-    })),
+    importProvidersFrom(BrowserModule, AppRoutingModule),
+    provideTranslateService({
+      loader: provideTranslateHttpLoader({ prefix: `${environment.locales}/assets/locales/`, suffix: '.json' }),
+    }),
     provideClientHydration(),
-    { provide: TitleStrategy, useClass: TranslateTitleStrategy }
+    { provide: TitleStrategy, useClass: TranslateTitleStrategy },
     //   {
     //     provide: APP_INITIALIZER,
     //     useFactory: appInitializerFactory,
     //     deps: [ Injector ],
     //     multi: true
     //   }
-    ,
-    provideHttpClient(withInterceptorsFromDi())
-  ]
-}
+    provideHttpClient(withInterceptorsFromDi()),
+  ],
+};

--- a/src/app/app.utils.ts
+++ b/src/app/app.utils.ts
@@ -1,17 +1,9 @@
 import { Injector } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-
-import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { LocalizeRouterService } from '@gilsdav/ngx-translate-router';
 import { firstValueFrom } from 'rxjs';
 import { filter, first, tap } from 'rxjs/operators';
 import { NavigationEnd, Router } from '@angular/router';
-import { environment } from '../environments/environment';
-
-export function createTranslateLoader(http: HttpClient) {
-  return new TranslateHttpLoader(http, `${environment.locales}/assets/locales/`, '.json');
-}
 
 export const appInitializerFactory = (injector: Injector) => {
   return () => {


### PR DESCRIPTION
Added support for @ngx-translate/core v17 and @ngx-translate/http-loader v17

Main issue was pointed out in https://github.com/ngx-translate/core/issues/1592, they changed [`getParsedResult`](https://github.com/ngx-translate/core/commit/ce040be4555ef75c6939351963a23860ed9967c0#diff-f0ff2bbfe57aaec468aa21c208c916edb2a13b775f4408f4a698d9e6bfc1e07bL405) which was not documented in migration guide.

I have
- Updated `"@ngx-translate/core": "17.0.0"`
- Updated `"@ngx-translate/http-loader": "17.0.0"` (for demo only)
- Fixed `LocalizeParser.translateText` to call `getParsedResult` without translations object
- Updated `LocalizeParser.init` to call `setFallbackLang` instead of deprecated `setDefaultLang`
- Updated demo to work with newer versions

I have NOT
- Tested `LocalizeRouterHttpLoader`
- Tested Scully plugin
- Renamed all *internal* `defaultLang` with `fallbackLang`. This could be done with another PR if needed

Closes #170 